### PR TITLE
[FIX] improved projects page responsiveness.

### DIFF
--- a/components/Projects/Project.tsx
+++ b/components/Projects/Project.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useAppSelector } from '../../app/hooks';
 import { useDispatch } from 'react-redux';
 import { openModal } from '../../store/slices/sliceModal';
 import { ProjectProps } from './Project.interface';
+import thumbnail from '../../public/open-source.png';
 
 export const Project = ({ title, description, tags, author }: ProjectProps) => {
   const mode = useAppSelector((state) => state.mode.mode);
@@ -12,10 +12,6 @@ export const Project = ({ title, description, tags, author }: ProjectProps) => {
   const handleContribute = () => {
     return;
   };
-  const [innerWidth, setInnerWidth] = useState(0);
-  useEffect(() => {
-    setInnerWidth(window.innerWidth);
-  }, []);
   return (
     <div className="w-full p-2 md:p-0">
       <div
@@ -23,23 +19,18 @@ export const Project = ({ title, description, tags, author }: ProjectProps) => {
           mode
             ? 'text-white bg-box-color border border-[#363D45]'
             : 'text-dark-color border border-[#C9C9C9]'
-        } text-white shadow-md rounded-md items-center flex-col md:flex md:flex-row justify-center space-y-2`}
+        } text-white shadow-md rounded-md items-center flex-col flex justify-center space-y-2`}
       >
-        <div className="w-full p-2 flex justify-center items-center">
-          <Image
-            src={'/open-source.png'}
-            alt={title}
-            height={800}
-            width={innerWidth/1.2}
-          />
+        <div className="w-full">
+          <Image src={thumbnail} alt={title} placeholder="blur" />
         </div>
-        <div className="h-full flex flex-col justify-between space-y-2 p-2">
-          <h1 className="font-semibold text-xl">
+        <div className="flex flex-col gap-5 p-4 pt-2">
+          <h1 className="text-xl font-semibold">
             {title} - <span className="text-lg font-light">{author}</span>
           </h1>
           <p className="text-sm ">{description}</p>
-          <div className="flex flex-col md:flex-row md:justify-between md:items-center">
-            <div className="flex space-x-2 pb-2 md:pb-0">
+          <div className="flex flex-col gap-5">
+            <div className="flex pb-2 space-x-2 md:pb-0">
               {tags.map((tag: string, i: number) => (
                 <p
                   key={i}
@@ -57,9 +48,9 @@ export const Project = ({ title, description, tags, author }: ProjectProps) => {
               onClick={() =>
                 userLogged ? handleContribute : dispatch(openModal())
               }
-              className={`px-2 py-1.5 mt-2 sm:my-0 flex border border-[#999] focus:ring focus:bg-blue-800 bg-secondary-color ${
+              className={`border border-[#999] focus:ring focus:bg-blue-800 bg-secondary-color ${
                 !mode && 'text-white'
-              } rounded-md`}
+              } rounded-md px-2 py-1.5 mt-2 sm:my-0 flex justify-center`}
             >
               <span>Contribute</span>
             </button>

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -35,7 +35,7 @@ const Projects = () => {
         >
           <Search />
         </div>
-        <div className="w-full md:w-1/2 mt-16 mb-4 mx-auto space-y-4">
+        <div className="container gap-5 m-auto mt-20 md:p-5 md:grid md:grid-cols-2 xl:grid-cols-3">
           {projects.map((project) => {
             return (
               <Project

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -35,7 +35,7 @@ const Projects = () => {
         >
           <Search />
         </div>
-        <div className="container gap-5 m-auto mt-20 md:p-5 md:grid md:grid-cols-2 xl:grid-cols-3">
+        <div className="container gap-5 m-auto mt-20 md:p-5 md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
           {projects.map((project) => {
             return (
               <Project


### PR DESCRIPTION
### Changes proposed

I noticed that projects section is not properly responsive, the image was scaling weirdly on different screen sizes and also there were way too much white spaces on the sides which didn't look very good. I added grid to the projects wrapper so we can use the white spaces for showing more cards on larger screen size.

### Screenshots

before changes :

![before changes](https://res.cloudinary.com/dakts9ect/image/upload/v1663398052/opensource/before_gbtidt.gif)

after changes :

![after changes](https://res.cloudinary.com/dakts9ect/image/upload/v1663398059/opensource/after_ciu8o6.gif)