### PR TITLE
Fix: Replace 'any' and make strongly typed components

### DIFF
--- a/interfaces/schema/postSchema.ts
+++ b/interfaces/schema/postSchema.ts
@@ -14,11 +14,7 @@ export const postSchema = z.object({
     required_error: 'githubRepository is required',
   }),
 
-  coverImg: z
-    .string({
-      required_error: 'Cover image is required',
-    })
-    .url(),
+  coverImg: z.string().url().optional(),
 
   tags: z.array(z.string()).min(1).max(5),
 });

--- a/lib/httpResponse.ts
+++ b/lib/httpResponse.ts
@@ -1,14 +1,13 @@
+import { Project } from '@prisma/client';
 import { NextApiResponse } from 'next';
 
 /**
  * @desc    Send any success response
  */
-export /** */
-const successResponse = (args: {
+export const successResponse = (args: {
   res: NextApiResponse;
   message: string;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  results: any;
+  results: Project | boolean | null | unknown;
   success: boolean;
   statusCode: number;
 }) => {
@@ -41,7 +40,7 @@ export const errorResponse = (args: {
  */
 export const validationResponse = (args: {
   res: NextApiResponse;
-  error: any;
+  error: unknown;
 }) => {
   const { res, error } = args;
   res.status(400).json({

--- a/pages/projects/submit.tsx
+++ b/pages/projects/submit.tsx
@@ -15,7 +15,7 @@ type FormInputs = {
   projectName: string;
   repositoryLink: string;
   projectDescription: string;
-  coverImage: any;
+  coverImage: string | null;
 };
 
 const SubmitProject = () => {
@@ -75,6 +75,8 @@ const SubmitProject = () => {
       alert(e.message);
     }
   };
+
+  const coverImageValue = watch('coverImage');
 
   return (
     <SharedLayout title="Submit Project">
@@ -221,15 +223,15 @@ const SubmitProject = () => {
               <label className="text-lg">Cover Image</label>
               <div
                 className={`relative mx-auto flex rounded-md h-[300px] ${
-                  watch('coverImage')
+                  coverImageValue
                     ? 'border-2 border-green-700 border-dashed'
                     : ''
                 }`}
               >
-                {watch('coverImage') ? (
+                {coverImageValue ? (
                   <>
                     <Image
-                      src={watch('coverImage')}
+                      src={coverImageValue}
                       alt="project-image"
                       className="h-full w-full object-contain"
                       layout="fill"

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,7 @@ model Project {
   title            String
   description      String
   githubRepository String
-  coverImg         String
+  coverImg         String?
   tags             String[]
   comment          Comment[]
   createdAt        DateTime  @default(now())


### PR DESCRIPTION
<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

### Fixes Issue
Closes #178 

### Changes proposed
- Replace `any` with more suitable types in the `httpResponse.ts` file
- Replace `any` type of `coverImage` in `SubmitProject` component and make cover image optional