### PR TITLE
fixed layout issue

### DIFF
--- a/components/Layouts/SharedLayout.tsx
+++ b/components/Layouts/SharedLayout.tsx
@@ -6,12 +6,14 @@ interface IProps {
   children: React.ReactNode;
   title: string;
   hideFooter?: boolean;
+  hasContainer?: boolean;
 }
 
 export const SharedLayout: React.FC<IProps> = ({
   children,
   title,
   hideFooter,
+  hasContainer,
 }) => {
   const year = new Date().getFullYear();
 
@@ -22,7 +24,9 @@ export const SharedLayout: React.FC<IProps> = ({
         <link rel="icon" href="/dark-logo.svg" />
       </Head>
       <Topbar />
-      <main className="m-auto max-w-screen-xl">{children}</main>
+      <main className={(hasContainer && 'm-auto max-w-screen-xl') || ''}>
+        {children}
+      </main>
       {!hideFooter && (
         <footer className="sticky top-[100%] border px-5 py-10 text-center dark:border-gray-800">
           This project is published under{' '}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,11 +9,13 @@ import {
 
 const Home: NextPage = () => {
   return (
-    <SharedLayout title="Home">
-      <Hero />
-      <Guide />
-      <BenefitsContainer />
-      <About />
+    <SharedLayout title="Home" hasContainer>
+      <div>
+        <Hero />
+        <Guide />
+        <BenefitsContainer />
+        <About />
+      </div>
     </SharedLayout>
   );
 };

--- a/pages/user/profile.tsx
+++ b/pages/user/profile.tsx
@@ -24,7 +24,7 @@ const Profile: NextPage = () => {
   }
 
   return (
-    <SharedLayout title="Profile">
+    <SharedLayout title="Profile" hasContainer>
       <div className="m-auto flex w-full flex-col px-4 py-5">
         <h1 className="text-xl font-semibold dark:text-[#a6a6a6] sm:text-[30px]">
           <span>Welcome back, </span>


### PR DESCRIPTION
### Changes proposed

instead of having a static max width on `SharedLayout`  , I added a `hasContainer` prop to it so you can render layout without a max width in case you need the whole viewport on a page.

### Screenshots

before changes : 

![image](https://user-images.githubusercontent.com/83041367/195019790-420545b1-9226-442e-afd5-13d58d60c1c7.png)

after changes : 

![image](https://user-images.githubusercontent.com/83041367/195019698-2c74b17a-8f32-45f6-ac3d-5b41f9bd52a8.png)
