### PR TITLE
Refactoring Tags component

### DIFF
--- a/components/Tags/Tag.tsx
+++ b/components/Tags/Tag.tsx
@@ -1,0 +1,26 @@
+import { motion } from 'framer-motion';
+import { AiFillCloseCircle } from 'react-icons/ai';
+import { TagProps } from './Tags.interface';
+
+export const Tag = ({ title, className, onClick, onClose }: TagProps) => {
+  const isClickable = !!onClick;
+  return (
+    <motion.span
+      layout
+      onClick={isClickable ? (e) => onClick(e, title) : undefined}
+      className={`group flex w-max ${
+        isClickable ? 'cursor-pointer' : 'cursor-default'
+      } flex-wrap items-center rounded-full bg-background-2 !bg-slate-100 px-3 py-1 !text-slate-800 focus:ring dark:!bg-slate-900 dark:!text-slate-200 ${className}`}
+    >
+      <>
+        {title}
+        {onClose && (
+          <AiFillCloseCircle
+            className="ml-2 cursor-pointer"
+            onClick={(e) => onClose(e, title)}
+          />
+        )}
+      </>
+    </motion.span>
+  );
+};

--- a/components/Tags/Tags.interface.ts
+++ b/components/Tags/Tags.interface.ts
@@ -9,3 +9,12 @@ export type TagsProps = {
   removeTagHandler?: RemoveTagFc;
   className?: string;
 };
+
+export type OnTagClick = (event: MouseEvent, tagTitle: string) => void;
+
+export type TagProps = {
+  title: string;
+  onClick?: OnTagClick;
+  onClose?: OnTagClick;
+  className?: string;
+};

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -1,7 +1,6 @@
 import { TagsProps } from './Tags.interface';
 import { useMemo } from 'react';
-import { AiFillCloseCircle } from 'react-icons/ai';
-import { motion } from 'framer-motion';
+import { Tag } from './Tag';
 
 export const Tags = ({
   tags,
@@ -29,32 +28,24 @@ export const Tags = ({
     return tempArray;
   }, [maximumCharactersToShow, maximumTagsToShow, tags]);
 
+  const areTagClosable = !!removeTagHandler;
+
   return (
     <div className={`flex ${className}`}>
       {tagsToShow.map((tag: string, i: number) => {
         return (
-          <motion.span
-            layout
+          <Tag
+            title={tag}
             key={i}
-            onClick={
-              removeTagHandler
-                ? (event) => removeTagHandler(event, i)
-                : undefined
+            onClose={
+              areTagClosable ? (e) => removeTagHandler?.(e, i) : undefined
             }
-            className="group flex w-max cursor-pointer flex-wrap items-center rounded-full bg-background-2 !bg-slate-100 px-3 py-1 !text-slate-800 focus:ring dark:!bg-slate-900 dark:!text-slate-200"
-          >
-            <>
-              {tag}
-              {removeTagHandler && <AiFillCloseCircle className="ml-2" />}
-            </>
-          </motion.span>
+          />
         );
       })}
       {(maximumTagsToShow || maximumCharactersToShow) &&
         tags.length - tagsToShow.length > 0 && (
-          <span className="group flex w-max cursor-pointer flex-wrap items-center rounded-full bg-background-2 !bg-slate-100 px-2 py-1 !text-slate-800 focus:ring dark:!bg-slate-900 dark:!text-slate-200">
-            +{tags.length - tagsToShow.length}
-          </span>
+          <Tag title={`+${tags.length - tagsToShow.length}`} />
         )}
     </div>
   );

--- a/components/Tags/Tags.tsx
+++ b/components/Tags/Tags.tsx
@@ -37,9 +37,7 @@ export const Tags = ({
           <Tag
             title={tag}
             key={i}
-            onClose={
-              areTagClosable ? (e) => removeTagHandler?.(e, i) : undefined
-            }
+            onClose={areTagClosable ? (e) => removeTagHandler(e, i) : undefined}
           />
         );
       })}


### PR DESCRIPTION
### Fixes Issue

Closes #292 

### Changes proposed

First of all, I abstracted a single "Tag" component and then used it into the already existing "Tags" component.
Then, if before the "removing" of a tag was done on click upon all of it, now it's only on click upon the close icon (in that way it's possible to have both an onclick general and a onclose)

### Note to reviewers

That lies the base for a next PR which I'm working on: Filtering by tags. I think to create a "MultiSelectionTags" that will exploit the single Tag component to create a multi-selection reusable input.

### Screenshots
