### PR TITLE
feat: Added Tooltip component

### DIFF
--- a/components/Layouts/SharedLayout.tsx
+++ b/components/Layouts/SharedLayout.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { motion } from 'framer-motion';
 import { getSocialLinks } from '../Topbar/data';
 import { ISharedLayout } from './Layouts.interface';
+import { Tooltip } from '../Tooltip';
 
 export const SharedLayout: React.FC<ISharedLayout> = ({
   children,
@@ -40,7 +41,9 @@ export const SharedLayout: React.FC<ISharedLayout> = ({
                   href={url}
                   className="flex items-center justify-center text-3xl text-slate-400 hover:text-slate-100"
                 >
-                  {<Icon />}
+                  <Tooltip text={title} direction="top">
+                    {<Icon />}
+                  </Tooltip>
                 </motion.a>
               ))}
             </div>

--- a/components/Tooltip/Tooltip.tsx
+++ b/components/Tooltip/Tooltip.tsx
@@ -1,0 +1,17 @@
+import { ReactElement, FC } from 'react';
+import { TooltipBox } from './TooltipBox';
+
+export const Tooltip: FC<{
+  children: ReactElement;
+  text: string;
+  direction?: 'top' | 'bottom' | 'left' | 'right';
+}> = (props) => {
+  const { children, text, direction } = props;
+
+  return (
+    <div className="group relative">
+      {children}
+      <TooltipBox text={text} direction={direction} />
+    </div>
+  );
+};

--- a/components/Tooltip/TooltipBox.tsx
+++ b/components/Tooltip/TooltipBox.tsx
@@ -1,0 +1,46 @@
+import { FC } from 'react';
+
+export const TooltipBox: FC<{
+  text: string;
+  direction?: 'top' | 'bottom' | 'left' | 'right';
+}> = (props) => {
+  const { text, direction } = props;
+
+  const directionStyles = [
+    'absolute z-[1000] invisible h-max w-max max-w-[15rem] rounded-md bg-gray-600 p-2 text-center text-xs leading-relaxed text-white group-hover:visible',
+  ];
+  const tooltipBoxArrowStyles = ['absolute h-0 w-0 border-transparent'];
+
+  switch (direction) {
+    case 'left':
+      directionStyles.push('mr-4 right-full top-1/2 -translate-y-1/2');
+      tooltipBoxArrowStyles.push(
+        'top-1/2 -translate-y-1/2 left-full border-l-gray-600 border-t-transparent border-b-transparent border-t-[6px] border-b-[6px] border-l-[6px]'
+      );
+      break;
+    case 'right':
+      directionStyles.push('ml-4 left-full top-1/2 -translate-y-1/2');
+      tooltipBoxArrowStyles.push(
+        'top-1/2 -translate-y-1/2 right-full border-r-gray-600 border-t-transparent border-b-transparent border-t-[6px] border-b-[6px] border-r-[6px]'
+      );
+      break;
+    case 'top':
+      directionStyles.push('mb-4 bottom-full right-1/2 translate-x-1/2');
+      tooltipBoxArrowStyles.push(
+        'left-1/2 -translate-x-1/2 top-full border-t-gray-600 border-l-transparent border-r-transparent border-l-[6px] border-r-[6px] border-t-[6px]'
+      );
+      break;
+    default:
+      directionStyles.push('mt-4 top-full right-1/2 translate-x-1/2');
+      tooltipBoxArrowStyles.push(
+        'left-1/2 -translate-x-1/2 bottom-full border-b-gray-600 border-l-transparent border-r-transparent border-l-[6px] border-r-[6px] border-b-[6px]'
+      );
+  }
+
+  return (
+    <div className={directionStyles.join(' ')}>
+      {text}
+      <span className={tooltipBoxArrowStyles.join(' ')}></span>
+    </div>
+  );
+};

--- a/components/Tooltip/TooltipBox.tsx
+++ b/components/Tooltip/TooltipBox.tsx
@@ -7,7 +7,7 @@ export const TooltipBox: FC<{
   const { text, direction } = props;
 
   const directionStyles = [
-    'absolute z-[1000] invisible h-max w-max max-w-[15rem] rounded-md bg-gray-600 p-2 text-center text-xs leading-relaxed text-white group-hover:visible',
+    'invisible absolute z-[1000] h-max w-max max-w-[15rem] rounded-md border-2 border-gray-600 bg-gray-600 p-2 text-center text-xs leading-relaxed text-white group-hover:visible',
   ];
   const tooltipBoxArrowStyles = ['absolute h-0 w-0 border-transparent'];
 
@@ -15,25 +15,25 @@ export const TooltipBox: FC<{
     case 'left':
       directionStyles.push('mr-4 right-full top-1/2 -translate-y-1/2');
       tooltipBoxArrowStyles.push(
-        'top-1/2 -translate-y-1/2 left-full border-l-gray-600 border-t-transparent border-b-transparent border-t-[6px] border-b-[6px] border-l-[6px]'
+        'top-1/2 left-full -translate-y-1/2 border-t-[6px] border-b-[6px] border-l-[6px] border-l-gray-600 border-t-transparent border-b-transparent'
       );
       break;
     case 'right':
       directionStyles.push('ml-4 left-full top-1/2 -translate-y-1/2');
       tooltipBoxArrowStyles.push(
-        'top-1/2 -translate-y-1/2 right-full border-r-gray-600 border-t-transparent border-b-transparent border-t-[6px] border-b-[6px] border-r-[6px]'
+        'top-1/2 right-full -translate-y-1/2 border-t-[6px] border-b-[6px] border-r-[6px] border-r-gray-600 border-t-transparent border-b-transparent'
       );
       break;
     case 'top':
       directionStyles.push('mb-4 bottom-full right-1/2 translate-x-1/2');
       tooltipBoxArrowStyles.push(
-        'left-1/2 -translate-x-1/2 top-full border-t-gray-600 border-l-transparent border-r-transparent border-l-[6px] border-r-[6px] border-t-[6px]'
+        'left-1/2 top-full -translate-x-1/2 border-l-[6px] border-r-[6px] border-t-[6px] border-t-gray-600 border-l-transparent border-r-transparent'
       );
       break;
     default:
       directionStyles.push('mt-4 top-full right-1/2 translate-x-1/2');
       tooltipBoxArrowStyles.push(
-        'left-1/2 -translate-x-1/2 bottom-full border-b-gray-600 border-l-transparent border-r-transparent border-l-[6px] border-r-[6px] border-b-[6px]'
+        'left-1/2 bottom-full -translate-x-1/2 border-l-[6px] border-r-[6px] border-b-[6px] border-b-gray-600 border-l-transparent border-r-transparent'
       );
   }
 

--- a/components/Tooltip/index.ts
+++ b/components/Tooltip/index.ts
@@ -1,0 +1,2 @@
+export { Tooltip } from './Tooltip';
+export { TooltipBox } from './TooltipBox';


### PR DESCRIPTION
Hi! I created a tooltip version.

### Fixes Issue

Closes #354 

### Changes proposed

Added `Tooltip` component. The `children` element and the `TooltipBox` are in a wrapper `div`.
Added `TooltipBox` component. The tooltip box appears on hover effect. It can appears on left, right, top or bottom (by default). The maximum width of the tooltip box is 15rem. Currently it also appears when the user tap the selected element in mobile view.
Addes `index.ts`.

### Screenshots
![tooltip](https://user-images.githubusercontent.com/41576384/220128819-5f7d0ee8-d2d4-46c9-b796-64e0a2437d54.png)

