### PR TITLE
[FEATURE] ability to delete our projects #335

### DIFF
--- a/components/Profile/Project/Project.tsx
+++ b/components/Profile/Project/Project.tsx
@@ -5,6 +5,7 @@ import { FaEdit, FaTrash } from 'react-icons/fa';
 import { AiFillEye } from 'react-icons/ai';
 import { useRouter } from 'next/router';
 import moment from 'moment';
+import axios from 'axios';
 
 interface IProject {
   title: string;
@@ -12,6 +13,7 @@ interface IProject {
   description: string;
   tags: Array<string>;
   createdAt: string;
+  handleDelete: (arg1: string) => void;
 }
 
 export const Project: FC<IProject> = ({
@@ -19,10 +21,35 @@ export const Project: FC<IProject> = ({
   description,
   id,
   createdAt,
+  handleDelete,
 }) => {
   const router = useRouter();
   const gotoProjectDetails = (id: string) => {
     router.push(`/projects/${id}`);
+  };
+  //delteProject function is responsible to call the delete API when the yes button is clicked in the popup
+  async function deleteProject(id: string) {
+    const url = `/api/user/project?projectId=${id}`;
+    const result = await axios
+      .delete(`/api/user/project?projectId=${id}`)
+      .then((res) => res.data)
+      .catch((error) => error.message);
+    closeModal();
+    //once the delete operation has been performed the profile page has to be updated with new list of projects so handleDelete is a props passed by the parent component which let the parent component knows that a project has been deleted so that parent component can update the state
+    handleDelete(id);
+  }
+  // openModal and closeModal functions are responsible for opening and closing of modal
+  const openModal = () => {
+    const modal = document.getElementById('myModal');
+    if (modal) {
+      modal.classList.remove('hidden');
+    }
+  };
+  const closeModal = () => {
+    const modal = document.getElementById('myModal');
+    if (modal) {
+      modal.classList.add('hidden');
+    }
   };
   return (
     <motion.li
@@ -32,6 +59,34 @@ export const Project: FC<IProject> = ({
       transition={{ duration: 1 }}
       className="flex w-full flex-col items-start justify-between gap-4 rounded-lg border border-gray-700 bg-slate-800 p-2 text-gray-100 shadow-border-shadow transition-all hover:shadow-md md:p-4"
     >
+      {/*Modal code */}
+      <div
+        id="myModal"
+        className="modal fixed inset-0 z-10 hidden overflow-y-auto"
+      >
+        <div className="modal-overlay absolute h-full w-full bg-gray-900 opacity-50"></div>
+        <div className="modal-content absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 transform rounded-lg bg-white p-8 shadow-lg">
+          <h2 className="mb-4 text-2xl font-bold text-black">
+            Are you sure you want to delete it?
+          </h2>
+          <div className="item-center flex flex-row justify-center gap-2 md:gap-3">
+            <button
+              className="flex flex-row items-center justify-center gap-2 rounded-md bg-green-900 p-3 px-2 py-1 text-red-100 transition-all hover:opacity-70 md:px-3 md:py-2"
+              onClick={() => deleteProject(id)}
+            >
+              <span>Yes</span>
+            </button>
+            <button
+              className="flex flex-row items-center justify-center gap-2 rounded-md bg-red-900 p-3 px-2 py-1 text-red-100 transition-all hover:opacity-70 md:px-3 md:py-2"
+              onClick={() => closeModal()}
+            >
+              <span>No</span>
+            </button>
+          </div>
+        </div>
+      </div>
+      {/*Motion Code end*/}
+
       <div className="flex w-full flex-row items-center justify-between">
         <Typography
           as="p"
@@ -76,8 +131,9 @@ export const Project: FC<IProject> = ({
           <span>Edit</span>
         </button>
         <button
-          className="flex cursor-not-allowed flex-row items-center justify-center gap-2 rounded-md bg-red-900 p-3 px-2 py-1 text-red-100 transition-all hover:opacity-70 md:px-3 md:py-2"
+          className="flex flex-row items-center justify-center gap-2 rounded-md bg-red-900 p-3 px-2 py-1 text-red-100 transition-all hover:opacity-70 md:px-3 md:py-2"
           aria-label={`Delete ${title}`}
+          onClick={() => openModal()}
         >
           <FaTrash aria-hidden="true" />
           <span>Delete</span>

--- a/components/Profile/Project/Project.tsx
+++ b/components/Profile/Project/Project.tsx
@@ -29,11 +29,18 @@ export const Project: FC<IProject> = ({
   };
   //delteProject function is responsible to call the delete API when the yes button is clicked in the popup
   async function deleteProject(id: string) {
+    const yesButton = document.getElementById('yesButton');
+    if (yesButton) {
+      yesButton.classList.add('cursor-not-allowed');
+    }
     const url = `/api/user/project?projectId=${id}`;
     const result = await axios
       .delete(`/api/user/project?projectId=${id}`)
       .then((res) => res.data)
       .catch((error) => error.message);
+    if (yesButton) {
+      yesButton.classList.remove('cursor-not-allowed');
+    }
     closeModal();
     //once the delete operation has been performed the profile page has to be updated with new list of projects so handleDelete is a props passed by the parent component which let the parent component knows that a project has been deleted so that parent component can update the state
     handleDelete(id);
@@ -71,6 +78,7 @@ export const Project: FC<IProject> = ({
           </h2>
           <div className="item-center flex flex-row justify-center gap-2 md:gap-3">
             <button
+              id="yesButton"
               className="flex flex-row items-center justify-center gap-2 rounded-md bg-green-900 p-3 px-2 py-1 text-red-100 transition-all hover:opacity-70 md:px-3 md:py-2"
               onClick={() => deleteProject(id)}
             >

--- a/components/UserBio/UserBio.tsx
+++ b/components/UserBio/UserBio.tsx
@@ -8,8 +8,12 @@ import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import useSWR from 'swr';
 import axios from 'axios';
+type MyProps = {
+  projectNumbers: number;
+};
 
-export const UserBio: React.FC = () => {
+export const UserBio: React.FC<MyProps> = ({ projectNumbers }) => {
+  // here we are using projectNumbers as the props which is passed by the parent so that whenever parent component updates its state the Child Component UserBio also gets re-rendered with the new number of projects
   const router = useRouter();
   const [isDescriptionClamped, setIsDescriptionClamped] = useState(true);
   const fetcher = (url: string) => axios.get(url).then((res) => res.data);
@@ -132,10 +136,10 @@ export const UserBio: React.FC = () => {
           fontSize="xl"
           fontWeight="medium"
           className={`mx-2  sm:text-base ${
-            numberOfProjects === 0 ? 'text-red-500' : 'text-gray-100'
+            projectNumbers === 0 ? 'text-red-500' : 'text-gray-100'
           }`}
         >
-          {numberOfProjects}
+          {projectNumbers}
         </Typography>
       </div>
       <button

--- a/pages/api/user/project.ts
+++ b/pages/api/user/project.ts
@@ -38,7 +38,26 @@ export default async function handler(
           success: false,
         });
       }
-
+    //delete api has been created to delete a user project
+    case 'DELETE':
+      const { projectId } = req.query;
+      try {
+        const data = await deleteProject(projectId?.toString());
+        return successResponse({
+          res,
+          message: 'Succesfully Deleted',
+          results: data,
+          statusCode: 200,
+          success: true,
+        });
+      } catch (error) {
+        return errorResponse({
+          res,
+          message: 'Internal Error',
+          statusCode: 500,
+          success: false,
+        });
+      }
     default:
       return errorResponse({
         res,
@@ -48,7 +67,16 @@ export default async function handler(
       });
   }
 }
-
+async function deleteProject(projectId?: string) {
+  try {
+    const data: Project | null = await prisma.project.delete({
+      where: { id: projectId },
+    });
+    return data;
+  } catch (error) {
+    throw error;
+  }
+}
 async function getProject(session: Session) {
   try {
     const data: Project[] = await prisma.project.findMany({


### PR DESCRIPTION
…ded popup to confirm deletion

<!-- If your PR fixes an open issue, use `Closes #101` to link your PR with the issue. #101 stands for the issue number you are fixing -->

### Fixes Issue
Closes #335
<!-- Remove this section if not applicable -->

<!-- Example: Closes #31 -->

### Changes proposed

<!-- List all the proposed changes in your PR -->
I have created the delete functionality upon clicking the Yes button and the profile page will get re-rendered with updated projects list. For this functionality I had to make some changes listing down

1. I had to implement state managment in "/pages/user/profile" using useState and useEffect hook so that I can store the lists of project as state and whenever a project is deleted ,I can update the state and the page gets re-rendered

2. I had to pass props to UserBio component inside Profile page component because easrlier there as no props getting passed in UserBio component it was fetching the data from API because of which the project numbers section in profile page was not getting updated when the project got deleted because when user Profile got re-rendered the child component UserBio didnt get re-rendered as there was no suspectible change in it . So to make it re-rendered I passed projectNumbers as a props , so whenever profile page state gets updated, projectsNumber also get changed and UserBio component gets re-rendered

3. Created a delete api in api/user/project file

4. Created the functionality of popup by creating the functionality of open and closed Modal

### Note to reviewers

<!-- Add notes to reviewers if applicable -->

### Screenshots
![image](https://user-images.githubusercontent.com/57058345/230468688-7f05975c-e646-4d54-a217-f72b04428615.png)
![image](https://user-images.githubusercontent.com/57058345/230468716-3fe14072-4523-43a2-bfce-b0268b42f8d1.png)
![image](https://user-images.githubusercontent.com/57058345/230468742-c2ec2c0a-210b-4421-9ae5-3ea6b328c01f.png)

